### PR TITLE
add rebel-readline to server repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ docs/.jekyll-metadata
 .cpcache
 .shadow-cljs
 resources/public/workspaces
+.rebel_readline_history

--- a/deps.edn
+++ b/deps.edn
@@ -29,10 +29,12 @@
            ;; See https://github.com/clojure-emacs/cider-nrepl/blob/master/deps.edn for Emacs support
            :dev       {:extra-paths ["src/test" "src/dev" "src/workspaces"]
                        :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"]
+                       :main-opts  ["-m" "rebel-readline.main"]
                        :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.520"}
                                      thheller/shadow-cljs        {:mvn/version "2.8.40"}
                                      expound                     {:mvn/version "0.7.2"}
                                      fulcrologic/fulcro-spec     {:mvn/version "3.1.2"}
                                      binaryage/devtools          {:mvn/version "0.9.10"}
+                                     com.bhauman/rebel-readline {:mvn/version "0.1.4"}
                                      ;nubank/workspaces           {:mvn/version "1.0.3"},
                                      org.clojure/tools.namespace {:mvn/version "0.3.0"}}}}}


### PR DESCRIPTION
This improves the `server repl` experience like so 

<img width="1280" alt="Screenshot 2019-08-08 at 8 24 03 AM" src="https://user-images.githubusercontent.com/12799326/62671847-07f20a00-b9b6-11e9-8ab1-08bda3488e5d.png">
