### PR TITLE
Fix wrong data structures in index-explorer resolver

### DIFF
--- a/src/main/app/server_components/pathom.clj
+++ b/src/main/app/server_components/pathom.clj
@@ -16,8 +16,8 @@
    ::pc/output [:com.wsscode.pathom.viz.index-explorer/index]}
   {:com.wsscode.pathom.viz.index-explorer/index
    (-> (get env ::pc/indexes)
-     (update ::pc/index-resolvers #(into [] (map (fn [[k v]] [k (dissoc v ::pc/resolve)])) %))
-     (update ::pc/index-mutations #(into [] (map (fn [[k v]] [k (dissoc v ::pc/mutate)])) %)))})
+     (update ::pc/index-resolvers #(into {} (map (fn [[k v]] [k (dissoc v ::pc/resolve)])) %))
+     (update ::pc/index-mutations #(into {} (map (fn [[k v]] [k (dissoc v ::pc/mutate)])) %)))})
 
 (def all-resolvers [acct/resolvers session/resolvers index-explorer])
 


### PR DESCRIPTION
While pruning the functions out of the pathom index some maps are converted to vectors and the explorer just shows `nil` in the resolvers / mutations section.
![image](https://user-images.githubusercontent.com/2965273/67419907-df99a500-f5cd-11e9-9721-ad081af018ac.png)
