### PR TITLE
Add a quick start section to the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,5 @@ docs/.jekyll-metadata
 /ReferenceGuide.html
 .cpcache
 .shadow-cljs
-resources/public/workspaces
+resources/public/workspaces/*
+!resources/public/workspaces/index.html

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,11 @@
 == The Project
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 NOTE: This template is in progress. It should be working, but is intended to have a lot more features.
 

--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,50 @@ You will want to enable the `:dev` dependency while developing this project.  In
 
 The main project source is in `src/main`.
 
+== Quick Start
+This is a manual to get started with this example project.
+It comes with `npm run` scripts pre-loaded, you can find them in the package.json file.
+
+```Shell
+# The shadow-cljs compiler is a dependency.
+yarn install
+# Of course you can use npm if you like.
+
+#### Develop components with cljs ####
+# Workspaces:
+
+npm run client/workspaces
+
+# Visit http://localhost:8023
+# Have a look at src/workspaces and https://github.com/nubank/workspaces
+
+#### Refreshing tests in the browser ####
+# CLJS Tests:
+npm run client/test
+# Visit http://localhost:8022
+
+#### full-stack development ####
+# Start the cljs compiler for the main target
+npm run client/main
+
+## Start the backend process:
+clojure -A:dev -Dtrace -Dghostwheel.enabled=true
+# The ns is defined in src/dev/user
+## Start the server
+user=> (start)
+## After modifications of the backend code:
+user=> (restart)
+## visit http://localhost:3000
+```
+=== The shadow-cljs compile server
+You can find the UI of the compile server here:
+http://localhost:9630
+There you can kick of the compilation of the other targets.
+
+=== Connect to the CLJS nREPL:
+1. Open and connect your nREPL to localhost:9000.
+2. Execute `(shadow/repl :main)`. (you can select another target of course)
+
 == Setting Up
 
 The shadow-cljs compiler uses all js dependencies through

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     },
     "scripts": {
         "client/main": "npx shadow-cljs watch :main",
+        "client/workspaces": "npx shadow-cljs watch :workspaces",
+        "client/test": "npx shadow-cljs watch :test",
         "client/cljs": "shadow-cljs cljs-repl :main",
         "client/clj": "shadow-cljs clj-repl",
         "client/server": "npx shadow-cljs server",

--- a/resources/public/workspaces/index.html
+++ b/resources/public/workspaces/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Client - Workspaces</title>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+</head>
+<body>
+<div id="app"></div>
+<!-- you might need to change the js path depending on your configuration -->
+<script src="js/main.js" type="text/javascript"></script>
+</body>
+</html>

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -34,6 +34,6 @@
                        :output-dir "resources/public/workspaces/js"
                        :asset-path "/workspaces/js"
                        :devtools   {:preloads           [com.fulcrologic.fulcro.inspect.preload]
-                                    :http-root          "resources/public"
+                                    :http-root          "resources/public/workspaces"
                                     :http-port          8023
                                     :http-resource-root "."}}}}


### PR DESCRIPTION
I was approached by colleagues because the README is deterrent. They felt overwhelmed and didn't know where to start.

This pull request does three things:
1. A new quick start section in the beginning of the README with all shell comands to get going. 
2. It adds a index.html to `resources/public/workspaces` and a `npm run` script for workspaces, so that new users can play with components in workspaces right away without having to start the backend.
3. It renders the ascii doc admonitions as symbols on github:
![image](https://user-images.githubusercontent.com/2965273/67684203-03c10180-f993-11e9-9a90-9b1dde764206.png)