### PR TITLE
README: Add download of the template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,9 @@ This is a manual to get started with this example project.
 It comes with `npm run` scripts pre-loaded, you can find them in the package.json file.
 
 ```Shell
+git clone git@github.com:fulcrologic/fulcro-template.git fulcro-app
+cd fulcro-app
+
 # The shadow-cljs compiler is a dependency.
 yarn install
 # Of course you can use npm if you like.


### PR DESCRIPTION
I think the Quick start is better if it includes actually getting the template so you can simply go through it and copy-paste to your terminal.