### PR TITLE
trivial edit: git clone suggestion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ It comes with helper `npm run` scripts pre-loaded, you can find them in the pack
 Typically you want to start the server and the _main_ and/or _workspaces_ (if you decided to use Nubank Workspaces) client builds. See below. You can simply start everything from the command line
 
 ```Shell
-git clone git@github.com:fulcrologic/fulcro-template.git fulcro-app
+git clone --depth 1 -o fulcro-template https://github.com/fulcrologic/fulcro-template.git fulcro-app
 cd fulcro-app
 
 # The shadow-cljs compiler is a dependency.


### PR DESCRIPTION
I changed the git clone command to use the https:// address, use -o so that I can keep "origin" for my project's real git origin, and depth of 1 because I don't care about the template's history.

Just a suggestion, not trying to get in a flame war or anything.