### PR TITLE
fix asset-path for workspaces build

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -32,7 +32,7 @@
           :workspaces {:target     nubank.workspaces.shadow-cljs.target
                        :ns-regexp  "-(test|ws)$"
                        :output-dir "resources/public/workspaces/js"
-                       :asset-path "/workspaces/js"
+                       :asset-path "js"
                        :devtools   {:preloads           [com.fulcrologic.fulcro.inspect.preload]
                                     :http-root          "resources/public/workspaces"
                                     :http-port          8023


### PR DESCRIPTION
Problem:
Not able to load assets (source maps particularly) on workspaces build
![image](https://user-images.githubusercontent.com/389119/89118776-23043680-d4b1-11ea-98fa-8c2bfe9a1a8b.png)
Solution:
workspaces already separated from other build by `http-root` path, hence could be removed from `asset-path`, which fixed problem