### PR TITLE
Changed merge/integrate-ident* to targeting/integrate-ident*

### DIFF
--- a/src/main/app/model/account.cljs
+++ b/src/main/app/model/account.cljs
@@ -2,7 +2,6 @@
   (:require
     [taoensso.timbre :as log]
     [com.fulcrologic.fulcro.mutations :as m :refer [defmutation]]
-    [com.fulcrologic.fulcro.algorithms.merge :as merge]
     [com.fulcrologic.fulcro.algorithms.data-targeting :as targeting]))
 
 (defn user-path
@@ -23,7 +22,7 @@
     (swap! state (fn [s]
                    (-> s
                      (insert-user* params)
-                     (merge/integrate-ident* [:account/id id] :append [:all-accounts])))))
+                     (targeting/integrate-ident* [:account/id id] :append [:all-accounts])))))
   (ok-action [env]
     (log/info "OK action"))
   (error-action [env]


### PR DESCRIPTION
Hi Tony

In `fulcro-template/src/main/app/model/account.cljs` the mutation `upsert-user` calls `merge/integrate-ident*` which appears to have been moved to `data-targeting/integrate-ident*`. I couldn't not find any reference to this in the changelogs so my apologies if this is an error. 

This PR changes `merge/integrate-ident*` to `targeting/integrate-ident*` and removes the unused `:require` of `c.f.f.algorithms.merge`

best regards,
Alex