### PR TITLE
Fix/484 autoadd tempids

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
            bidi/bidi                           {:mvn/version "2.1.6"}
            com.taoensso/timbre                 {:mvn/version "5.0.0"}
            com.wsscode/pathom                  {:mvn/version "2.2.31"}
-           com.fulcrologic/fulcro              {:mvn/version "3.4.4"}
+           com.fulcrologic/fulcro              {:mvn/version "3.5.5"}
            com.fulcrologic/fulcro-garden-css   {:mvn/version "3.0.8"}
            com.fulcrologic/semantic-ui-wrapper {:mvn/version "1.0.1"}
            com.fulcrologic/guardrails          {:mvn/version "0.0.12"}

--- a/src/dev/development.clj
+++ b/src/dev/development.clj
@@ -25,3 +25,6 @@
   (stop)
   (tools-ns/refresh :after 'development/start))
 
+(comment
+  (start)
+  (restart))

--- a/src/main/app/server_components/pathom.clj
+++ b/src/main/app/server_components/pathom.clj
@@ -45,7 +45,8 @@
                       {::p/mutate  pc/mutate-async
                        ::p/env     {::p/reader               [p/map-reader pc/parallel-reader
                                                               pc/open-ident-reader p/env-placeholder-reader]
-                                    ::p/placeholder-prefixes #{">"}}
+                                    ::p/placeholder-prefixes #{">"}
+                                    ::pc/mutation-join-globals [:tempids]}
                        ::p/plugins [(pc/connect-plugin {::pc/register all-resolvers})
                                     (p/env-wrap-plugin (fn [env]
                                                          ;; Here is where you can dynamically add things to the resolver/mutation


### PR DESCRIPTION
Ensure that tempids are always returned from mutations, even if the mutation has a mutation join (via m/returning) which does not specify :tempids. Plus some small improvements.

Feel free to either squash all the commits or tell me which ones to remove.

NOTE: The branch https://github.com/holyjak/fulcro-template/tree/fix/484-autoadd-tempids-demo / commit https://github.com/holyjak/fulcro-template/commit/644f7c9ecdfe3410f44340b8d8222cb1876b7819 demonstrates the issue (check it out, revert the pathom fix in c616498, and click the button; then try with the fix)