### PR TITLE
EQL transform to add ::p/errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/.jekyll-metadata
 .shadow-cljs
 resources/public/workspaces/*
 !resources/public/workspaces/index.html
+.calva/
+.lsp/.cache/
+.clj-kondo/.cache/

--- a/src/main/app/application.cljs
+++ b/src/main/app/application.cljs
@@ -2,7 +2,8 @@
   (:require
     [com.fulcrologic.fulcro.networking.http-remote :as net]
     [com.fulcrologic.fulcro.application :as app]
-    [com.fulcrologic.fulcro.components :as comp]))
+    [com.fulcrologic.fulcro.components :as comp]
+    [edn-query-language.core :as eql]))
 
 (def secured-request-middleware
   ;; The CSRF token is embedded via server_components/html.clj
@@ -10,12 +11,21 @@
     (net/wrap-csrf-token (or js/fulcro_network_csrf_token "TOKEN-NOT-IN-HTML!"))
     (net/wrap-fulcro-request)))
 
+(defn global-eql-transform
+  "As the default transform but also asking that any Pathom errors during load! are returned,
+  so that they can be inspected e.g. in `:remote-error?`"
+  [ast]
+  (cond-> (app/default-global-eql-transform ast)
+    (-> ast :type #{:root})
+    (update :children conj (eql/expr->ast :com.wsscode.pathom.core/errors))))
+
 (defonce SPA (app/fulcro-app
                {;; This ensures your client can talk to a CSRF-protected server.
                 ;; See middleware.clj to see how the token is embedded into the HTML
                 :remotes {:remote (net/fulcro-http-remote
                                     {:url                "/api"
-                                     :request-middleware secured-request-middleware})}}))
+                                     :request-middleware secured-request-middleware})}
+                :global-eql-transform global-eql-transform}))
 
 (comment
   (-> SPA (::app/runtime-atom) deref ::app/indexes))


### PR DESCRIPTION
...in the same way as fulcro-rad does, so that it is easier
to get hold of these e.g. inside `remote-error?`

Related to fulcrologic/fulcro#484